### PR TITLE
Create header/footer and about page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,24 @@
+export const metadata = {
+  title: "About CCPROS",
+};
+
+export default function AboutPage() {
+  return (
+    <div className="container mx-auto px-4 py-8 space-y-6">
+      <h2 className="text-2xl font-bold">About Us</h2>
+      <p>
+        Custom Creation Pros LLC (CCPROS) began in the building industry but
+        quickly pivoted toward technology under the leadership of founder Robin
+        Cornett. Driven by a passion for social justice and the potential of
+        AI, we develop tools that empower communities and restore rights.
+      </p>
+      <h2 className="text-2xl font-bold">Our Mission</h2>
+      <p>
+        We aim to create innovative products that make life easier while
+        leveling the playing field for everyone. Through research and
+        development we advocate for justice initiatives and strive to expand
+        access to opportunity across the United States and beyond.
+      </p>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ClerkProvider } from "@clerk/nextjs";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,7 +31,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <Header />
+        <main className="min-h-[calc(100vh-160px)]">{children}</main>
+        <Footer />
       </body>
     </html>
     </ClerkProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,103 +1,16 @@
-import Image from "next/image";
+import Link from "next/link";
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+    <div className="container mx-auto px-4 py-8 space-y-6">
+      <h1 className="text-3xl font-bold">Welcome to CCPROS</h1>
+      <p>
+        We build technology solutions focused on social justice and empowerment.
+        Learn more <Link href="/about" className="text-amber-700 underline">about us</Link>.
+      </p>
+      <div className="border-2 border-dashed border-amber-700 rounded p-8 text-center">
+        Chat interface coming soon.
+      </div>
     </div>
   );
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,9 @@
+export default function Footer() {
+  return (
+    <footer className="bg-amber-800 text-white p-4 mt-8">
+      <div className="container mx-auto text-center text-sm">
+        © {new Date().getFullYear()} CCPROS. All rights reserved.
+      </div>
+    </footer>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+
+export default function Header() {
+  return (
+    <header className="bg-amber-700 text-white p-4">
+      <nav className="container mx-auto flex justify-between items-center">
+        <h1 className="text-xl font-bold">CCPROS</h1>
+        <ul className="flex gap-4">
+          <li>
+            <Link href="/" className="hover:underline">
+              Home
+            </Link>
+          </li>
+          <li>
+            <Link href="/about" className="hover:underline">
+              About
+            </Link>
+          </li>
+        </ul>
+      </nav>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add Header and Footer components
- wire header & footer into layout
- replace default home page content and add chat placeholder
- add about page with text about CCPROS

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684717e67e908331bfa0968a727f5a9e