### PR TITLE
Add social profile, post and comment schemas

### DIFF
--- a/sanity/schema.ts
+++ b/sanity/schema.ts
@@ -2,5 +2,16 @@ import customer from "./schemas/customer"
 import user from "./schemas/user"
 import subscription from "./schemas/subscription"
 import purchase from "./schemas/purchase"
+import profile from "./schemas/profile"
+import post from "./schemas/post"
+import comment from "./schemas/comment"
 
-export const schemaTypes = [customer, user, subscription, purchase]
+export const schemaTypes = [
+  customer,
+  user,
+  subscription,
+  purchase,
+  profile,
+  post,
+  comment,
+]

--- a/sanity/schemas/comment.ts
+++ b/sanity/schemas/comment.ts
@@ -1,0 +1,33 @@
+import { defineType, defineField } from "sanity"
+
+const comment = defineType({
+  name: "comment",
+  title: "Comment",
+  type: "document",
+  fields: [
+    defineField({
+      name: "post",
+      title: "Post",
+      type: "reference",
+      to: [{ type: "post" }],
+    }),
+    defineField({
+      name: "author",
+      title: "Author",
+      type: "reference",
+      to: [{ type: "user" }],
+    }),
+    defineField({
+      name: "text",
+      title: "Text",
+      type: "text",
+    }),
+    defineField({
+      name: "createdAt",
+      title: "Created At",
+      type: "datetime",
+    }),
+  ],
+})
+
+export default comment

--- a/sanity/schemas/post.ts
+++ b/sanity/schemas/post.ts
@@ -1,0 +1,32 @@
+import { defineType, defineField } from "sanity"
+
+const post = defineType({
+  name: "post",
+  title: "Post",
+  type: "document",
+  fields: [
+    defineField({
+      name: "author",
+      title: "Author",
+      type: "reference",
+      to: [{ type: "user" }],
+    }),
+    defineField({
+      name: "title",
+      title: "Title",
+      type: "string",
+    }),
+    defineField({
+      name: "content",
+      title: "Content",
+      type: "text",
+    }),
+    defineField({
+      name: "createdAt",
+      title: "Created At",
+      type: "datetime",
+    }),
+  ],
+})
+
+export default post

--- a/sanity/schemas/profile.ts
+++ b/sanity/schemas/profile.ts
@@ -1,0 +1,54 @@
+import { defineType, defineField } from "sanity"
+
+const profile = defineType({
+  name: "profile",
+  title: "Profile",
+  type: "document",
+  fields: [
+    defineField({
+      name: "user",
+      title: "User",
+      type: "reference",
+      to: [{ type: "user" }],
+      description: "Associated Clerk user",
+    }),
+    defineField({
+      name: "handle",
+      title: "Handle",
+      type: "string",
+      description: "Unique profile handle",
+    }),
+    defineField({
+      name: "avatar",
+      title: "Avatar",
+      type: "image",
+    }),
+    defineField({
+      name: "bio",
+      title: "Bio",
+      type: "text",
+    }),
+    defineField({
+      name: "jobTitle",
+      title: "Job Title",
+      type: "string",
+    }),
+    defineField({
+      name: "company",
+      title: "Company",
+      type: "string",
+    }),
+    defineField({
+      name: "website",
+      title: "Website",
+      type: "url",
+    }),
+    defineField({
+      name: "location",
+      title: "Location",
+      type: "string",
+    }),
+  ],
+})
+
+export default profile


### PR DESCRIPTION
## Summary
- add Sanity document for user profiles with personal and professional info
- add Sanity document for posts
- add Sanity document for comments
- register the new schemas

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473f9aec48833199b59e8b8d3086c5