### PR TITLE
Add custom Clerk auth flow and dashboard

### DIFF
--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { currentUser } from "@clerk/nextjs/server";
+import { createClient } from "next-sanity";
+
+const client = createClient({
+  projectId: "8n5iznjt",
+  dataset: "production",
+  apiVersion: "2025-06-09",
+  token: process.env.SANITY_API_TOKEN,
+  useCdn: false,
+});
+
+export async function POST(req: NextRequest) {
+  const user = await currentUser();
+  if (!user) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const data = await req.json();
+
+  const userDoc = {
+    _type: "user",
+    _id: user.id,
+    clerkId: user.id,
+    email: user.primaryEmailAddress?.emailAddress,
+    fullName: data.fullName,
+    role: "user",
+  };
+
+  const profileDoc = {
+    _type: "profile",
+    user: { _type: "reference", _ref: user.id },
+    handle: data.handle,
+    bio: data.bio,
+    jobTitle: data.jobTitle,
+    company: data.company,
+    website: data.website,
+    location: data.location,
+  };
+
+  await client.createIfNotExists(userDoc);
+  await client.createIfNotExists(profileDoc);
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,26 @@
+import { currentUser } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import { client } from "@/app/sanity/client";
+
+export default async function DashboardPage() {
+  const user = await currentUser();
+  if (!user) redirect("/sign-in");
+
+  const profile = await client.fetch(
+    `*[_type == "profile" && user._ref == $id][0]`,
+    { id: user.id }
+  );
+
+  return (
+    <div className="container mx-auto px-4 py-8 space-y-6">
+      <h1 className="text-2xl font-bold">Dashboard</h1>
+      <p>Welcome {user.fullName}</p>
+      {profile && (
+        <div className="border p-4 rounded space-y-2">
+          <p className="font-semibold">@{profile.handle}</p>
+          {profile.bio && <p>{profile.bio}</p>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -1,0 +1,9 @@
+import { SignIn } from "@clerk/nextjs";
+
+export default function SignInPage() {
+  return (
+    <div className="container mx-auto max-w-md py-10">
+      <SignIn redirectUrl="/dashboard" />
+    </div>
+  );
+}

--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useState } from 'react';
+import { useSignUp } from '@clerk/nextjs';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+export default function SignUpPage() {
+  const { isLoaded, signUp, setActive } = useSignUp();
+  const router = useRouter();
+  const [pendingVerification, setPendingVerification] = useState(false);
+  const [code, setCode] = useState('');
+  const [error, setError] = useState('');
+  const [form, setForm] = useState({
+    email: '',
+    password: '',
+    fullName: '',
+    handle: '',
+    bio: '',
+    jobTitle: '',
+    company: '',
+    website: '',
+    location: '',
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isLoaded) return;
+    try {
+      await signUp.create({
+        emailAddress: form.email,
+        password: form.password,
+        firstName: form.fullName,
+      });
+      await signUp.prepareEmailAddressVerification({ strategy: 'email_code' });
+      setPendingVerification(true);
+    } catch (err: any) {
+      setError(err.errors?.[0]?.message || 'Sign up failed');
+    }
+  };
+
+  const onVerify = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isLoaded) return;
+    try {
+      const result = await signUp.attemptEmailAddressVerification({ code });
+      if (result.status === 'complete') {
+        await setActive({ session: result.createdSessionId });
+        await fetch('/api/profile', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(form),
+        });
+        router.push('/dashboard');
+      }
+    } catch (err: any) {
+      setError('Invalid verification code');
+    }
+  };
+
+  if (!isLoaded) return null;
+
+  if (pendingVerification) {
+    return (
+      <div className="container mx-auto max-w-md py-10 space-y-4">
+        <h1 className="text-xl font-bold">Verify your email</h1>
+        {error && <p className="text-destructive">{error}</p>}
+        <form onSubmit={onVerify} className="space-y-4">
+          <Input type="text" name="code" placeholder="Verification code" value={code} onChange={(e) => setCode(e.target.value)} />
+          <Button type="submit" className="w-full">Verify Email</Button>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-md py-10 space-y-4">
+      <h1 className="text-2xl font-bold">Create your account</h1>
+      {error && <p className="text-destructive">{error}</p>}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <Input name="email" type="email" placeholder="Email" value={form.email} onChange={handleChange} />
+        <Input name="password" type="password" placeholder="Password" value={form.password} onChange={handleChange} />
+        <Input name="fullName" type="text" placeholder="Full name" value={form.fullName} onChange={handleChange} />
+        <Input name="handle" type="text" placeholder="Handle" value={form.handle} onChange={handleChange} />
+        <Input name="jobTitle" type="text" placeholder="Job title" value={form.jobTitle} onChange={handleChange} />
+        <Input name="company" type="text" placeholder="Company" value={form.company} onChange={handleChange} />
+        <Input name="website" type="url" placeholder="Website" value={form.website} onChange={handleChange} />
+        <Input name="location" type="text" placeholder="Location" value={form.location} onChange={handleChange} />
+        <textarea name="bio" placeholder="Bio" value={form.bio} onChange={handleChange} className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm" />
+        <Button type="submit" className="w-full">Sign Up</Button>
+      </form>
+    </div>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,11 +1,12 @@
 import Link from "next/link";
+import { SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
 
 export default function Header() {
   return (
     <header className="bg-amber-700 text-white p-4">
       <nav className="container mx-auto flex justify-between items-center">
         <h1 className="text-xl font-bold">CCPROS</h1>
-        <ul className="flex gap-4">
+        <ul className="flex gap-4 items-center">
           <li>
             <Link href="/" className="hover:underline">
               Home
@@ -16,6 +17,23 @@ export default function Header() {
               About
             </Link>
           </li>
+          <SignedOut>
+            <li>
+              <Link href="/sign-in" className="hover:underline">
+                Sign In
+              </Link>
+            </li>
+          </SignedOut>
+          <SignedIn>
+            <li>
+              <Link href="/dashboard" className="hover:underline">
+                Dashboard
+              </Link>
+            </li>
+            <li>
+              <UserButton afterSignOutUrl="/" />
+            </li>
+          </SignedIn>
         </ul>
       </nav>
     </header>

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = "Input";
+
+export { Input };


### PR DESCRIPTION
## Summary
- add custom sign up form that collects profile fields and stores them in Sanity
- add sign in page and dashboard route
- expose endpoint for creating Sanity documents
- update header with auth links and user button
- add shadcn style input component

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684743f845808331b2f27aee87b78343