### PR TITLE
Fix default avatar logic in sidebar

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,0 +1,25 @@
+import { currentUser } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import Sidebar from "@/components/Sidebar";
+import { client } from "@/app/sanity/client";
+
+export default async function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const user = await currentUser();
+  if (!user) redirect("/sign-in");
+
+  const profile = await client.fetch(
+    `*[_type == "profile" && user._ref == $id][0]{handle,bio,avatar}`,
+    { id: user.id }
+  );
+
+  return (
+    <div className="container mx-auto px-4 py-8 flex gap-6">
+      <Sidebar user={user} profile={profile} />
+      <div className="flex-1">{children}</div>
+    </div>
+  );
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,26 +1,14 @@
 import { currentUser } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
-import { client } from "@/app/sanity/client";
 
 export default async function DashboardPage() {
   const user = await currentUser();
   if (!user) redirect("/sign-in");
 
-  const profile = await client.fetch(
-    `*[_type == "profile" && user._ref == $id][0]`,
-    { id: user.id }
-  );
-
   return (
-    <div className="container mx-auto px-4 py-8 space-y-6">
+    <div className="space-y-6">
       <h1 className="text-2xl font-bold">Dashboard</h1>
       <p>Welcome {user.fullName}</p>
-      {profile && (
-        <div className="border p-4 rounded space-y-2">
-          <p className="font-semibold">@{profile.handle}</p>
-          {profile.bio && <p>{profile.bio}</p>}
-        </div>
-      )}
     </div>
   );
 }

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,0 +1,43 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { urlForImage } from "@/lib/sanity-image";
+import type { User } from "@clerk/nextjs/server";
+import type { Image as SanityImage } from "sanity";
+
+interface SidebarProps {
+  user: User;
+  profile?: {
+    handle?: string;
+    bio?: string;
+    avatar?: SanityImage;
+  } | null;
+}
+
+export default function Sidebar({ user, profile }: SidebarProps) {
+  const avatarUrl = profile?.avatar
+    ? urlForImage(profile.avatar).width(64).height(64).url()
+    : user.hasImage
+      ? user.imageUrl
+      : undefined;
+
+  return (
+    <aside className="w-64 space-y-6">
+      <div className="flex flex-col items-center space-y-2 border p-4 rounded">
+        <Avatar className="h-16 w-16 border-2 border-border">
+          {avatarUrl ? (
+            <AvatarImage src={avatarUrl} alt={user.fullName || "User avatar"} />
+          ) : (
+            <AvatarFallback className="text-xl font-semibold">
+              {user.firstName?.[0]}
+            </AvatarFallback>
+          )}
+        </Avatar>
+        <p className="font-semibold">{profile?.handle || user.username || user.id}</p>
+        {profile?.bio && (
+          <p className="text-sm text-center text-muted-foreground">
+            {profile.bio.length > 80 ? profile.bio.slice(0, 77) + "..." : profile.bio}
+          </p>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Avatar = React.forwardRef<HTMLSpanElement, React.HTMLAttributes<HTMLSpanElement>>(
+  ({ className, ...props }, ref) => (
+    <span
+      ref={ref}
+      className={cn("relative flex shrink-0 overflow-hidden rounded-full border", className)}
+      {...props}
+    />
+  )
+);
+Avatar.displayName = "Avatar";
+
+const AvatarImage = React.forwardRef<HTMLImageElement, React.ImgHTMLAttributes<HTMLImageElement>>(
+  ({ className, ...props }, ref) => (
+    <img ref={ref} className={cn("aspect-square h-full w-full", className)} {...props} />
+  )
+);
+AvatarImage.displayName = "AvatarImage";
+
+const AvatarFallback = React.forwardRef<HTMLSpanElement, React.HTMLAttributes<HTMLSpanElement>>(
+  ({ className, ...props }, ref) => (
+    <span
+      ref={ref}
+      className={cn(
+        "flex h-full w-full items-center justify-center rounded-full bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+AvatarFallback.displayName = "AvatarFallback";
+
+export { Avatar, AvatarImage, AvatarFallback };

--- a/lib/sanity-image.ts
+++ b/lib/sanity-image.ts
@@ -1,0 +1,9 @@
+import imageUrlBuilder from "@sanity/image-url";
+import type { Image } from "sanity";
+import { client } from "@/app/sanity/client";
+
+const builder = imageUrlBuilder(client);
+
+export function urlForImage(source: Image) {
+  return builder.image(source);
+}


### PR DESCRIPTION
## Summary
- fix avatar fallback to use Clerk uploaded image only when present
- clean up unused import in Sidebar component

## Testing
- `npm run lint` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_68474f53de508331b7002cccf672bf3a