### PR TITLE
Fix hydration mismatch

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import { SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
 

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import { cn } from "@/lib/utils";
 

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import { cn } from "@/lib/utils";
 


### PR DESCRIPTION
## Summary
- mark Header as a client component
- mark UI components as client components so event handlers work

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847aed5a58c8331bc762df169625139