### PR TITLE
Fix default avatar in sidebar

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -16,7 +16,9 @@ interface SidebarProps {
 }
 
 export default function Sidebar({ user, profile }: SidebarProps) {
-  const avatarUrl = profile?.avatar? urlForImage(profile.avatar).width(64).height(64).url() : undefined;
+  const avatarUrl = profile?.avatar
+    ? urlForImage(profile.avatar).width(64).height(64).url()
+    : "https://github.com/shadcn.png";
 
  
 
@@ -27,14 +29,10 @@ export default function Sidebar({ user, profile }: SidebarProps) {
 
 
         <Avatar className="h-16 w-16 border-2 border-border">
- 
-          {avatarUrl ? (
-            <AvatarImage src={avatarUrl} alt={user.fullName || "User avatar"} />
-          ) : (
-            <AvatarFallback className="text-xl font-semibold">
-              {user.firstName?.[0]}
-            </AvatarFallback>
-          )}
+          <AvatarImage src={avatarUrl} alt={user.fullName || "User avatar"} />
+          <AvatarFallback className="text-xl font-semibold">
+            {user.firstName?.[0]}
+          </AvatarFallback>
         </Avatar>
         <p className="font-semibold">{profile?.handle || user.username || user.id}</p>
         {profile?.bio && (


### PR DESCRIPTION
## Summary
- always provide a default avatar image when the user has no avatar in Sanity

## Testing
- `npm install` *(fails: `next` not found)*


------
https://chatgpt.com/codex/tasks/task_e_6847b12a6670833189cb457cef1ad323