### PR TITLE
Fix DashboardLayout safeUser reference

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -13,10 +13,10 @@ export default async function DashboardLayout({
 
   // Build a plain user object so we don't pass a Clerk class instance to the client
   const safeUser = {
-    id,
-    fullName,
-    firstName,
-    username,
+    id: user.id,
+    fullName: user.fullName,
+    firstName: user.firstName,
+    username: user.username,
   };
 
   const profile = await client.fetch(


### PR DESCRIPTION
## Summary
- fix safeUser object to use properties from `user` instance

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684997a110508331b6a571a3772ddc33