### PR TITLE
Fix Sanity client token usage

### DIFF
--- a/app/api/avatar/route.ts
+++ b/app/api/avatar/route.ts
@@ -1,14 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
-import { createClient } from "next-sanity";
-
-const client = createClient({
-  projectId: "8n5iznjt",
-  dataset: "production",
-  apiVersion: "2025-06-09",
-  token: process.env.SANITY_API_TOKEN,
-  useCdn: false,
-});
+import { client } from "@/app/sanity/client";
 
 export async function POST(req: NextRequest) {
   const user = await currentUser();

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -1,14 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
-import { createClient } from "next-sanity";
-
-const client = createClient({
-  projectId: "8n5iznjt",
-  dataset: "production",
-  apiVersion: "2025-06-09",
-  token: process.env.SANITY_API_TOKEN,
-  useCdn: false,
-});
+import { client } from "@/app/sanity/client";
 
 export async function POST(req: NextRequest) {
   const user = await currentUser();

--- a/app/sanity/client.ts
+++ b/app/sanity/client.ts
@@ -4,5 +4,6 @@ export const client = createClient({
   projectId: "8n5iznjt",
   dataset: "production",
   apiVersion: "2025-06-09",
+  token: process.env.SANITY_API_TOKEN,
   useCdn: false,
 })


### PR DESCRIPTION
## Summary
- include `SANITY_API_TOKEN` in the shared Sanity client
- reuse the shared client in profile and avatar API routes

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a0428be08331b413c53a01c1223e