### PR TITLE
Fix user reference errors in Sanity

### DIFF
--- a/app/api/avatar/route.ts
+++ b/app/api/avatar/route.ts
@@ -1,14 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
-import { createClient } from "next-sanity";
-
-const client = createClient({
-  projectId: "8n5iznjt",
-  dataset: "production",
-  apiVersion: "2025-06-09",
-  token: process.env.SANITY_API_TOKEN,
-  useCdn: false,
-});
+import { client } from "@/app/sanity/client";
+import { ensureUser } from "@/app/sanity/user";
 
 export async function POST(req: NextRequest) {
   const user = await currentUser();
@@ -29,6 +22,11 @@ export async function POST(req: NextRequest) {
     { id: user.id }
   );
   if (!profileId) {
+    await ensureUser({
+      id: user.id,
+      email: user.primaryEmailAddress?.emailAddress,
+      fullName: user.fullName,
+    });
     const created = await client.create({
       _type: "profile",
       user: { _type: "reference", _ref: user.id },

--- a/app/sanity/client.ts
+++ b/app/sanity/client.ts
@@ -4,5 +4,6 @@ export const client = createClient({
   projectId: "8n5iznjt",
   dataset: "production",
   apiVersion: "2025-06-09",
+  token: process.env.SANITY_API_TOKEN,
   useCdn: false,
 })

--- a/app/sanity/user.ts
+++ b/app/sanity/user.ts
@@ -1,0 +1,13 @@
+import { client } from "./client"
+
+export async function ensureUser(user: { id: string; email?: string | null; fullName?: string | null }) {
+  const userDoc = {
+    _type: "user",
+    _id: user.id,
+    clerkId: user.id,
+    email: user.email,
+    fullName: user.fullName,
+    role: "user",
+  }
+  await client.createIfNotExists(userDoc)
+}


### PR DESCRIPTION
## Summary
- add helper to create user documents in Sanity
- ensure avatar and profile API routes create a user before referencing it

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a0428be08331b413c53a01c1223e