### PR TITLE
Fix user reference errors in Sanity

### DIFF
--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -1,14 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
-import { createClient } from "next-sanity";
-
-const client = createClient({
-  projectId: "8n5iznjt",
-  dataset: "production",
-  apiVersion: "2025-06-09",
-  token: process.env.SANITY_API_TOKEN,
-  useCdn: false,
-});
+import { client } from "@/app/sanity/client";
+import { ensureUser } from "@/app/sanity/user";
 
 export async function POST(req: NextRequest) {
   const user = await currentUser();
@@ -18,18 +11,15 @@ export async function POST(req: NextRequest) {
 
   const data = await req.json();
 
-  const userDoc = {
-    _type: "user",
-    _id: user.id,
-    clerkId: user.id,
+  const docId = await ensureUser({
+    id: user.id,
     email: user.primaryEmailAddress?.emailAddress,
     fullName: data.fullName,
-    role: "user",
-  };
+  });
 
   const profileDoc = {
     _type: "profile",
-    user: { _type: "reference", _ref: user.id },
+    user: { _type: "reference", _ref: docId },
     handle: data.handle,
     bio: data.bio,
     jobTitle: data.jobTitle,
@@ -38,7 +28,6 @@ export async function POST(req: NextRequest) {
     location: data.location,
   };
 
-  await client.createIfNotExists(userDoc);
   const created = await client.createIfNotExists(profileDoc);
 
   return NextResponse.json({ profile: created });
@@ -50,15 +39,21 @@ export async function GET() {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 
+  const docId = await ensureUser({
+    id: user.id,
+    email: user.primaryEmailAddress?.emailAddress,
+    fullName: user.fullName,
+  });
+
   let profile = await client.fetch(
     '*[_type=="profile" && user._ref==$id][0]',
-    { id: user.id }
+    { id: docId }
   );
 
   if (!profile) {
     profile = await client.create({
       _type: "profile",
-      user: { _type: "reference", _ref: user.id },
+      user: { _type: "reference", _ref: docId },
     });
   }
 
@@ -72,15 +67,21 @@ export async function PUT(req: NextRequest) {
   }
 
   const data = await req.json();
+  const docId = await ensureUser({
+    id: user.id,
+    email: user.primaryEmailAddress?.emailAddress,
+    fullName: user.fullName,
+  });
+
   const profileId = await client.fetch(
     '*[_type=="profile" && user._ref==$id][0]._id',
-    { id: user.id }
+    { id: docId }
   );
 
   if (!profileId) {
     const created = await client.create({
       _type: "profile",
-      user: { _type: "reference", _ref: user.id },
+      user: { _type: "reference", _ref: docId },
       ...data,
     });
     return NextResponse.json({ profile: created });

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -2,6 +2,7 @@ import { currentUser } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import Sidebar from "@/components/Sidebar";
 import { client } from "@/app/sanity/client";
+import { ensureUser } from "@/app/sanity/user";
 
 export default async function DashboardLayout({
   children,
@@ -19,6 +20,12 @@ export default async function DashboardLayout({
     username: user.username,
   };
 
+  const docId = await ensureUser({
+    id: user.id,
+    email: user.primaryEmailAddress?.emailAddress,
+    fullName: user.fullName,
+  });
+
   let profile = await client.fetch(
     `*[_type == "profile" && user._ref == $id][0]{
       _id,
@@ -30,13 +37,13 @@ export default async function DashboardLayout({
       location,
       avatar
     }`,
-    { id: user.id }
+    { id: docId }
   );
 
   if (!profile) {
     profile = await client.create({
       _type: "profile",
-      user: { _type: "reference", _ref: user.id },
+      user: { _type: "reference", _ref: docId },
     });
   }
 

--- a/app/sanity/client.ts
+++ b/app/sanity/client.ts
@@ -4,5 +4,6 @@ export const client = createClient({
   projectId: "8n5iznjt",
   dataset: "production",
   apiVersion: "2025-06-09",
+  token: process.env.SANITY_API_TOKEN,
   useCdn: false,
 })

--- a/app/sanity/user.ts
+++ b/app/sanity/user.ts
@@ -1,0 +1,15 @@
+import { client } from "./client"
+
+export async function ensureUser(user: { id: string; email?: string | null; fullName?: string | null }) {
+  const docId = `user_${user.id}`
+  const userDoc = {
+    _type: "user",
+    _id: docId,
+    clerkId: user.id,
+    email: user.email,
+    fullName: user.fullName,
+    role: "user",
+  }
+  await client.createIfNotExists(userDoc)
+  return docId
+}


### PR DESCRIPTION
## Summary
- normalize user document IDs with `user_${id}` pattern
- create/fetch profiles using this ID consistently across API routes
- ensure dashboard layout references consistent user doc ID

## Testing
- `npm run lint` *(failed: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a0428be08331b413c53a01c1223e