### PR TITLE
Fix profile POST syntax

### DIFF
--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -13,7 +13,6 @@ export async function POST(req: NextRequest) {
   const data = await req.json();
 
   const docId = await ensureUser({
-  await ensureUser({
     id: user.id,
     email: user.primaryEmailAddress?.emailAddress,
     fullName: data.fullName,


### PR DESCRIPTION
## Summary
- fix duplicated call to `ensureUser` in the profile API

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a8e6845883319bfeefdce7a4e202