### PR TITLE
Implement dashboard post feed

### DIFF
--- a/app/api/friends/[id]/route.ts
+++ b/app/api/friends/[id]/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { currentUser } from "@clerk/nextjs/server";
+import { client } from "@/app/sanity/client";
+import { ensureUser } from "@/app/sanity/user";
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const user = await currentUser();
+  if (!user) return new NextResponse("Unauthorized", { status: 401 });
+
+  const docId = await ensureUser({
+    id: user.id,
+    email: user.primaryEmailAddress?.emailAddress,
+    fullName: user.fullName,
+  });
+
+  const existing = await client.fetch(
+    '*[_type=="friendship" && user._ref==$user && friend._ref==$friend][0]',
+    { user: docId, friend: params.id }
+  );
+  if (existing) return NextResponse.json({ friendship: existing });
+
+  const friendship = await client.create({
+    _type: "friendship",
+    user: { _type: "reference", _ref: docId },
+    friend: { _type: "reference", _ref: params.id },
+    status: "pending",
+    createdAt: new Date().toISOString(),
+  });
+
+  return NextResponse.json({ friendship });
+}
+
+export async function PUT(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const user = await currentUser();
+  if (!user) return new NextResponse("Unauthorized", { status: 401 });
+
+  const docId = await ensureUser({
+    id: user.id,
+    email: user.primaryEmailAddress?.emailAddress,
+    fullName: user.fullName,
+  });
+
+  const friendship = await client.fetch(
+    '*[_type=="friendship" && _id==$id][0]',
+    { id: params.id }
+  );
+  if (!friendship) return new NextResponse("Not Found", { status: 404 });
+  if (friendship.friend._ref !== docId)
+    return new NextResponse("Forbidden", { status: 403 });
+
+  const updated = await client.patch(params.id).set({ status: "accepted" }).commit();
+
+  return NextResponse.json({ friendship: updated });
+}

--- a/app/api/friends/route.ts
+++ b/app/api/friends/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { currentUser } from "@clerk/nextjs/server";
+import { client } from "@/app/sanity/client";
+import { ensureUser } from "@/app/sanity/user";
+
+export async function GET() {
+  const user = await currentUser();
+  if (!user) return new NextResponse("Unauthorized", { status: 401 });
+
+  const docId = await ensureUser({
+    id: user.id,
+    email: user.primaryEmailAddress?.emailAddress,
+    fullName: user.fullName,
+  });
+
+  const friends = await client.fetch(
+    `*[_type=="friendship" && ((user._ref==$id && status=='accepted') || (friend._ref==$id && status=='accepted'))]{
+      _id,status,
+      "user": user->{fullName,"handle":*[_type=='profile' && user._ref==^._id][0].handle},
+      "friend": friend->{fullName,"handle":*[_type=='profile' && user._ref==^._id][0].handle}
+    }`,
+    { id: docId }
+  );
+
+  return NextResponse.json({ friends });
+}

--- a/app/api/posts/[id]/route.ts
+++ b/app/api/posts/[id]/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { currentUser } from "@clerk/nextjs/server";
+import { client } from "@/app/sanity/client";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const post = await client.fetch(
+    `*[_type=="post" && _id==$id][0]{
+      _id,title,content,createdAt,
+      "author": author->{fullName,"handle":*[_type=='profile' && user._ref==^._id][0].handle}
+    }`,
+    { id: params.id }
+  );
+  if (!post) return new NextResponse("Not Found", { status: 404 });
+  return NextResponse.json({ post });
+}
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const user = await currentUser();
+  if (!user) return new NextResponse("Unauthorized", { status: 401 });
+
+  const post = await client.fetch(
+    '*[_type=="post" && _id==$id][0]{"authorId": author._ref}',
+    { id: params.id }
+  );
+  if (!post) return new NextResponse("Not Found", { status: 404 });
+  const docId = `user_${user.id}`;
+  if (post.authorId !== docId)
+    return new NextResponse("Forbidden", { status: 403 });
+
+  const data = await req.json();
+  const updated = await client
+    .patch(params.id)
+    .set({ title: data.title, content: data.content })
+    .commit();
+
+  return NextResponse.json({ post: updated });
+}

--- a/app/api/posts/route.ts
+++ b/app/api/posts/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { currentUser } from "@clerk/nextjs/server";
+import { client } from "@/app/sanity/client";
+import { ensureUser } from "@/app/sanity/user";
+
+export async function POST(req: NextRequest) {
+  const user = await currentUser();
+  if (!user) return new NextResponse("Unauthorized", { status: 401 });
+
+  const data = await req.json();
+  const docId = await ensureUser({
+    id: user.id,
+    email: user.primaryEmailAddress?.emailAddress,
+    fullName: user.fullName,
+  });
+
+  const postDoc = {
+    _type: "post",
+    author: { _type: "reference", _ref: docId },
+    title: data.title,
+    content: data.content,
+    createdAt: new Date().toISOString(),
+  };
+
+  const created = await client.create(postDoc);
+  return NextResponse.json({ post: created });
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const userId = searchParams.get("userId");
+  const query = userId
+    ? `*[_type=="post" && author._ref==$id]|order(createdAt desc){
+        _id,title,content,createdAt,
+        "author": author->{fullName,"handle":*[_type=='profile' && user._ref==^._id][0].handle}
+      }`
+    : `*[_type=="post"]|order(createdAt desc){
+        _id,title,content,createdAt,
+        "author": author->{fullName,"handle":*[_type=='profile' && user._ref==^._id][0].handle}
+      }`;
+  const posts = await client.fetch(query, { id: userId });
+  return NextResponse.json({ posts });
+}

--- a/app/dashboard/posts/[id]/edit/EditPostForm.tsx
+++ b/app/dashboard/posts/[id]/edit/EditPostForm.tsx
@@ -1,0 +1,46 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+export default function EditPostForm({ post }: { post: { _id: string; title: string; content: string } }) {
+  const [form, setForm] = useState({ title: post.title, content: post.content });
+  const [error, setError] = useState('');
+  const router = useRouter();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch(`/api/posts/${post._id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+    if (res.ok) {
+      router.push(`/posts/${post._id}`);
+    } else {
+      setError('Failed to update post');
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Edit Post</h1>
+      {error && <p className="text-destructive">{error}</p>}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <Input name="title" value={form.title} onChange={handleChange} />
+        <textarea
+          name="content"
+          value={form.content}
+          onChange={handleChange}
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+        />
+        <Button type="submit">Update</Button>
+      </form>
+    </div>
+  );
+}

--- a/app/dashboard/posts/[id]/edit/page.tsx
+++ b/app/dashboard/posts/[id]/edit/page.tsx
@@ -1,0 +1,13 @@
+import { client } from "@/app/sanity/client";
+import EditPostForm from "./EditPostForm";
+
+export default async function EditPostPage({ params }: { params: { id: string } }) {
+  const post = await client.fetch(
+    '*[_type=="post" && _id==$id][0]{ _id, title, content }',
+    { id: params.id }
+  );
+
+  if (!post) return <div className="container mx-auto py-10">Post not found</div>;
+
+  return <EditPostForm post={post} />;
+}

--- a/app/dashboard/posts/new/page.tsx
+++ b/app/dashboard/posts/new/page.tsx
@@ -1,0 +1,10 @@
+import CreatePostForm from '@/components/CreatePostForm'
+
+export default function NewPostPage() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">New Post</h1>
+      <CreatePostForm />
+    </div>
+  )
+}

--- a/app/dashboard/posts/page.tsx
+++ b/app/dashboard/posts/page.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import { currentUser } from "@clerk/nextjs/server";
+import { client } from "@/app/sanity/client";
+import { ensureUser } from "@/app/sanity/user";
+
+export default async function MyPostsPage() {
+  const user = await currentUser();
+  if (!user) return null;
+  const docId = await ensureUser({
+    id: user.id,
+    email: user.primaryEmailAddress?.emailAddress,
+    fullName: user.fullName,
+  });
+
+  const posts = await client.fetch(
+    '*[_type=="post" && author._ref==$id]|order(createdAt desc){ _id,title }',
+    { id: docId }
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">My Posts</h1>
+        <Link href="/dashboard/posts/new" className="underline">
+          New Post
+        </Link>
+      </div>
+      <ul className="list-disc list-inside space-y-1">
+        {posts.map((post: any) => (
+          <li key={post._id}>
+            <Link href={`/dashboard/posts/${post._id}/edit`}>{post.title}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/posts/[id]/page.tsx
+++ b/app/posts/[id]/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { client } from "@/app/sanity/client";
+
+export default async function PostPage({ params }: { params: { id: string } }) {
+  const post = await client.fetch(
+    `*[_type=='post' && _id==$id][0]{
+      _id,title,content,createdAt,
+      "author": author->{fullName,"handle":*[_type=='profile' && user._ref==^._id][0].handle}
+    }`,
+    { id: params.id }
+  );
+
+  if (!post) return <div className="container mx-auto py-10">Post not found</div>;
+
+  return (
+    <div className="container mx-auto px-4 py-8 space-y-4">
+      <h1 className="text-2xl font-bold">{post.title}</h1>
+      {post.author && (
+        <p className="text-sm text-muted-foreground">
+          by {post.author.handle ? (
+            <Link href={`/users/${post.author.handle}`}>{post.author.fullName}</Link>
+          ) : (
+            post.author.fullName
+          )}
+        </p>
+      )}
+      <div>{post.content}</div>
+    </div>
+  );
+}

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -1,20 +1,20 @@
-import Link from 'next/link'
-import { client } from '@/app/sanity/client'
-import CreatePostForm from '@/components/CreatePostForm'
+import Link from "next/link";
+import { client } from "@/app/sanity/client";
 
-export default async function DashboardPage() {
+export default async function PostsPage() {
   const posts = await client.fetch(
     `*[_type=='post']|order(createdAt desc){
-      _id,title,content,createdAt,
+      _id,title,createdAt,
       "author": author->{fullName,"handle":*[_type=='profile' && user._ref==^._id][0].handle}
     }`
-  )
+  );
 
   return (
-    <div className="relative h-full">
-      <div className="absolute inset-x-0 top-0 bottom-36 overflow-y-auto space-y-4 p-4">
+    <div className="container mx-auto px-4 py-8 space-y-6">
+      <h1 className="text-2xl font-bold">Posts</h1>
+      <ul className="space-y-4">
         {posts.map((post: any) => (
-          <div key={post._id} className="border rounded p-4 space-y-1">
+          <li key={post._id} className="border p-4 rounded">
             <h2 className="font-semibold">
               <Link href={`/posts/${post._id}`}>{post.title}</Link>
             </h2>
@@ -27,13 +27,9 @@ export default async function DashboardPage() {
                 )}
               </p>
             )}
-            {post.content && <p className="text-sm">{post.content}</p>}
-          </div>
+          </li>
         ))}
-      </div>
-      <div className="absolute bottom-0 inset-x-0 border-t bg-background p-4">
-        <CreatePostForm />
-      </div>
+      </ul>
     </div>
-  )
+  );
 }

--- a/app/users/[handle]/page.tsx
+++ b/app/users/[handle]/page.tsx
@@ -1,0 +1,62 @@
+import { currentUser } from "@clerk/nextjs/server";
+import Link from "next/link";
+import { client } from "@/app/sanity/client";
+import { ensureUser } from "@/app/sanity/user";
+import AddFriendButton from "@/components/AddFriendButton";
+
+export default async function UserProfilePage({ params }: { params: { handle: string } }) {
+  const profile = await client.fetch(
+    `*[_type=='profile' && handle==$handle][0]{
+      _id, handle, bio, jobTitle, company, website, location, avatar,
+      "userId": user._ref,
+      "fullName": user->fullName
+    }`,
+    { handle: params.handle }
+  );
+
+  if (!profile) return <div className="container mx-auto py-10">User not found</div>;
+
+  const user = await currentUser();
+  let friendship: any = null;
+  let viewerId: string | null = null;
+  if (user) {
+    viewerId = await ensureUser({
+      id: user.id,
+      email: user.primaryEmailAddress?.emailAddress,
+      fullName: user.fullName,
+    });
+    friendship = await client.fetch(
+      '*[_type=="friendship" && ((user._ref==$viewer && friend._ref==$target) || (user._ref==$target && friend._ref==$viewer))][0]{ _id,status,"userId":user._ref,"friendId":friend._ref }',
+      { viewer: viewerId, target: profile.userId }
+    );
+  }
+
+  const posts = await client.fetch(
+    `*[_type=='post' && author._ref==$id]|order(createdAt desc){ _id,title }`,
+    { id: profile.userId }
+  );
+
+  return (
+    <div className="container mx-auto px-4 py-8 space-y-6">
+      <h1 className="text-2xl font-bold">{profile.fullName}</h1>
+      {user && viewerId && user.id !== profile.userId.replace('user_', '') && (
+        <AddFriendButton
+          targetId={profile.userId}
+          viewerId={viewerId}
+          existing={friendship}
+        />
+      )}
+      {profile.bio && <p>{profile.bio}</p>}
+      <div className="space-y-2">
+        <h2 className="font-semibold">Posts</h2>
+        <ul className="list-disc list-inside space-y-1">
+          {posts.map((post: any) => (
+            <li key={post._id}>
+              <Link href={`/posts/${post._id}`}>{post.title}</Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/components/AddFriendButton.tsx
+++ b/components/AddFriendButton.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { useState } from 'react';
+import { Button } from './ui/button';
+
+interface Props {
+  targetId: string;
+  viewerId: string;
+  existing: any;
+}
+
+export default function AddFriendButton({
+  targetId,
+  viewerId,
+  existing,
+}: Props) {
+  const [status, setStatus] = useState(existing?.status || 'idle');
+
+  const sendRequest = async () => {
+    const res = await fetch(`/api/friends/${targetId}`, { method: 'POST' });
+    if (res.ok) {
+      setStatus('pending');
+    }
+  };
+
+  const acceptRequest = async () => {
+    const res = await fetch(`/api/friends/${existing._id}`, { method: 'PUT' });
+    if (res.ok) {
+      setStatus('accepted');
+    }
+  };
+
+  if (status === 'accepted') return null;
+
+  if (status === 'pending' && existing?.friendId === viewerId) {
+    return <Button onClick={acceptRequest}>Accept Request</Button>;
+  }
+
+  return (
+    <Button onClick={sendRequest} disabled={status === 'pending'}>
+      {status === 'pending' ? 'Request Sent' : 'Add Friend'}
+    </Button>
+  );
+}

--- a/components/CreatePostForm.tsx
+++ b/components/CreatePostForm.tsx
@@ -1,0 +1,45 @@
+'use client'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+export default function CreatePostForm() {
+  const [form, setForm] = useState({ title: '', content: '' })
+  const [error, setError] = useState('')
+  const router = useRouter()
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const res = await fetch('/api/posts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    })
+    if (res.ok) {
+      setForm({ title: '', content: '' })
+      router.refresh()
+    } else {
+      setError('Failed to create post')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      {error && <p className="text-destructive text-sm">{error}</p>}
+      <Input name="title" value={form.title} onChange={handleChange} placeholder="Title" />
+      <textarea
+        name="content"
+        value={form.content}
+        onChange={handleChange}
+        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+        placeholder="What's on your mind?"
+      />
+      <Button type="submit" className="w-full">Post</Button>
+    </form>
+  )
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
+import Link from "next/link";
 import { toast } from "sonner";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -180,6 +181,9 @@ export default function Sidebar({ user, profile: initialProfile }: SidebarProps)
         </div>
         <Button size="sm" onClick={openEditProfilePopup} className="w-full">
           Update Profile
+        </Button>
+        <Button asChild size="sm" variant="outline" className="w-full">
+          <Link href="/dashboard/posts">My Posts</Link>
         </Button>
       </div>
     </aside>

--- a/sanity/schema.ts
+++ b/sanity/schema.ts
@@ -5,6 +5,7 @@ import purchase from "./schemas/purchase"
 import profile from "./schemas/profile"
 import post from "./schemas/post"
 import comment from "./schemas/comment"
+import friendship from "./schemas/friendship"
 
 export const schemaTypes = [
   customer,
@@ -14,4 +15,5 @@ export const schemaTypes = [
   profile,
   post,
   comment,
+  friendship,
 ]

--- a/sanity/schemas/friendship.ts
+++ b/sanity/schemas/friendship.ts
@@ -1,0 +1,39 @@
+import { defineType, defineField } from "sanity"
+
+const friendship = defineType({
+  name: "friendship",
+  title: "Friendship",
+  type: "document",
+  fields: [
+    defineField({
+      name: "user",
+      title: "User",
+      type: "reference",
+      to: [{ type: "user" }],
+    }),
+    defineField({
+      name: "friend",
+      title: "Friend",
+      type: "reference",
+      to: [{ type: "user" }],
+    }),
+    defineField({
+      name: "status",
+      title: "Status",
+      type: "string",
+      options: {
+        list: [
+          { title: "Pending", value: "pending" },
+          { title: "Accepted", value: "accepted" },
+        ],
+      },
+    }),
+    defineField({
+      name: "createdAt",
+      title: "Created At",
+      type: "datetime",
+    }),
+  ],
+})
+
+export default friendship


### PR DESCRIPTION
## Summary
- replace dashboard landing page with public posts feed
- add fixed create post form at the bottom of the dashboard feed
- share create post logic via `CreatePostForm` component
- remove Posts link from the main header
- allow accepting friend requests from another user's profile

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849abba22488331828aee144836f9f9