### PR TITLE
Hide navbar on chiefcommand page

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,9 +1,15 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
 
 export default function Header() {
+  const pathname = usePathname();
+  if (pathname.startsWith("/chiefcommand")) {
+    return null;
+  }
+
   return (
     <header className="bg-amber-700 text-white p-4">
       <nav className="container mx-auto flex justify-between items-center">


### PR DESCRIPTION
## Summary
- ensure the main header is hidden on `/chiefcommand`

## Testing
- `npx next lint` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ed1b38008331bd1eb02e262e8677