### PR TITLE
Fix hydration mismatch

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className="document-body-full-width">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >


### PR DESCRIPTION
## Summary
- add missing `document-body-full-width` class to `<html>` element

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f77f08708331b3390454401e7f19