### PR TITLE
Fix avatar visibility on chiefcommand page

### DIFF
--- a/app/chiefcommand/page.tsx
+++ b/app/chiefcommand/page.tsx
@@ -1,6 +1,11 @@
 'use client'
 
-import HologramScene from './components/HologramScene'
+import dynamic from 'next/dynamic'
+
+// Load the three.js scene only on the client to avoid SSR issues
+const HologramScene = dynamic(() => import('./components/HologramScene'), {
+  ssr: false,
+})
 
 export default function Home() {
   return (


### PR DESCRIPTION
## Summary
- ensure HologramScene only renders on the client

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a0a6315f88331bdc067bd2d2f866e